### PR TITLE
feat(types): add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,10 @@
 // Project: https://github.com/lyserio/electron-nucleus
 
 export interface Nucleus {
+  init: ( 
+    appId: string,
+    config?: {} 
+  ) => void;
   setUserId: (id: number | string) => void;
   onError: (
     type: "uncaughtException" | "unhandledRejection" | "windowError",
@@ -15,6 +19,13 @@ export interface Nucleus {
   ) => void;
   disableTracking: () => void;
   enableTracking: () => void;
+  checkLicense: (
+    license: string,
+    callback: Callback<any>
+  ) => void;
+  getCustomData: ( callback: Callback<any> ) => void;
+  checkUpdates: () => void;
+  onUpdate: ( version: string ) => void;
 }
 
 declare const nucleus: (
@@ -22,13 +33,13 @@ declare const nucleus: (
   config?: {
     /*  disable module while in development (default: false) */
     disableInDev?: boolean;
-    /*  completely disable tracking */
+    /*  completely disable tracking (default: false) */
     disableTracking?: boolean;
-    /*  if you can only use Nucleus in the mainprocess */
+    /*  if you can only use Nucleus in the mainprocess (default: false)*/
     onlyMainProcess?: boolean;
     /*  disable errors reporting (default: false) */
     disableErrorReports?: boolean;
-    /*  auto gives the user an id: username@hostname default: boolean */
+    /*  auto gives the user an id: username@hostname rdefault: false) */
     autoUserId?: boolean;
     /*  set an identifier for this user */
     userId?: number | string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for electron-nucleus
+// Project: https://github.com/lyserio/electron-nucleus
+
+export interface Nucleus {
+  setUserId: (id: number | string) => void;
+  onError: (
+    type: "uncaughtException" | "unhandledRejection" | "windowError",
+    error: Error
+  ) => void;
+  trackError: (name: string, error: Error) => void;
+  setProps: (props: { [key: string]: string | number | boolean }) => void;
+  track: (
+    customEvent: string,
+    data?: { [key: string]: string | number | boolean }
+  ) => void;
+  disableTracking: () => void;
+  enableTracking: () => void;
+}
+
+declare const nucleus: (
+  appId: string,
+  config?: {
+    /*  disable module while in development (default: false) */
+    disableInDev?: boolean;
+    /*  completely disable tracking */
+    disableTracking?: boolean;
+    /*  if you can only use Nucleus in the mainprocess */
+    onlyMainProcess?: boolean;
+    /*  disable errors reporting (default: false) */
+    disableErrorReports?: boolean;
+    /*  auto gives the user an id: username@hostname default: boolean */
+    autoUserId?: boolean;
+    /*  set an identifier for this user */
+    userId?: number | string;
+    /*  cache events to disk if offline to report later (default: false) */
+    persist?: boolean;
+    /*  set a custom version for your app (default: autodetected) */
+    version?: string;
+    /*  specify a custom language (default: autodetected) */
+    language?: string;
+  }
+) => Nucleus;
+
+export default nucleus;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.0",
   "description": "Analytics and bug reporting for Electron.",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lyserio/electron-nucleus.git"


### PR DESCRIPTION
Just testing out this tool on our project, and looks pretty handy 👌.

I added these locally based on the documentation and they seem to cover the api nicely.

Happy to submit these to definitely typed instead though if you'd prefer to avoid maintaining these as part of the project.

