### PR TITLE
fix(typescript): remove callback type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,9 +21,9 @@ export interface Nucleus {
   enableTracking: () => void;
   checkLicense: (
     license: string,
-    callback: Callback<any>
+    callback: (error: Error | null, licenseInfo?: any) => void,
   ) => void;
-  getCustomData: ( callback: Callback<any> ) => void;
+  getCustomData: (callback: (error: Error | null, customData?: any) => void) => void;
   checkUpdates: () => void;
   onUpdate: ( version: string ) => void;
 }


### PR DESCRIPTION
Fixes an issue with Callback type in typescript definitions introduced in https://github.com/lyserio/electron-nucleus/pull/7/commits/cb58097052806625b68512841ad3da2d4d3871d1.

I'm assuming this handy looking generic exists in flow or possibly a typescript library that you've previously used.

Unfortunately it doesn't exist in typescript out of the box, so this caused the types to break.

I based the types for the these methods off the index.js file.

